### PR TITLE
Ensy 187 bursar transfer success email from bursar transfer lambda should include number of lines and total charges

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,38 +18,38 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:734bf24b9240a366b4a0d7e37433ef01664a3568d8bb65be583cc2a4ed2947c5",
-                "sha256:9f36834a1a777002b4b4600415ced83bc62d42b9c36d8c75f5fc007a58d0ae17"
+                "sha256:8149f17587c68e556743018f213f00ece81a0f021adb9b9b697a2ee8802583d7",
+                "sha256:8860ab54a26d1d596d64fc9de7e40c4d7c53c100311208cbd90d9272c3385513"
             ],
             "index": "pypi",
-            "version": "==1.28.42"
+            "version": "==1.28.51"
         },
         "boto3-stubs": {
             "extras": [
                 "s3"
             ],
             "hashes": [
-                "sha256:496075f1de47e3984d9a367798d2c46ae7405fa0142b2668ba3ff2f2c2982b3f",
-                "sha256:8bc7382eab400e81824bdb2444f9268641aa76dcbe84a145f7afc9a4bfad76ff"
+                "sha256:67608ad5ccd862494dc4aac8dc7596393f3d9cd2123a78bcd1f3ac46f3799cb3",
+                "sha256:6ebd53a356faaf576b3dd77c0923ab725b51da46d85adf6e2a89569b360490c0"
             ],
             "index": "pypi",
-            "version": "==1.28.42"
+            "version": "==1.28.51"
         },
         "botocore": {
             "hashes": [
-                "sha256:a51607e9f367e53768d37eacde244bc31dbaff4e7dde453cc772a8f75648f04a",
-                "sha256:cedf7d5eb55f120faadd56d3bced2139523479adb4df62c0c5ee5d46b2ffa836"
+                "sha256:8e133add22f07b55d21e14176b97b82e993d5f9aca70f5b0cd0908cb105ba53a",
+                "sha256:91dfb38801d45214875a892bd1e908fc7a894c2ed170bacd67e6929af72f2bd2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.42"
+            "version": "==1.31.51"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:172e2178f0683cdef1006a360deb82cafee4d4974bea53fdc40fb27f47997222",
-                "sha256:215a55fe840fe621d7fe6406bbe369ea98443340b6ce233961b17f20ae61869f"
+                "sha256:159a57ff41ed16940da6c3e0ee2f4d9571bc6d345a1f41b36a85a093dd15aeff",
+                "sha256:a31d93723fab3cd40cefb3c82ce7fe86bb901ee52cee20424e949118028afc26"
             ],
             "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==1.31.42"
+            "version": "==1.31.51"
         },
         "certifi": {
             "hashes": [
@@ -92,11 +92,11 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:2e53ad63f96bb9da6570ba2e755c267e529edcf58580a2c0d2a11ef26e1e678b",
-                "sha256:7dc873b87e1faf4d00614afd1058bfa1522942f33daef8a59f90de8ed75cd10c"
+                "sha256:64a7141005fb775b9db298a30de93e3b83e0ddd1232dc6f36eb38aebc1553291",
+                "sha256:6de2e88304873484207fed836388e422aeff000609b104c802749fd89d56ba5b"
             ],
             "index": "pypi",
-            "version": "==1.30.0"
+            "version": "==1.31.0"
         },
         "six": {
             "hashes": [
@@ -124,11 +124,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
-                "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
+                "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
+                "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
             ],
             "markers": "python_version < '3.12'",
-            "version": "==4.7.1"
+            "version": "==4.8.0"
         },
         "urllib3": {
             "hashes": [
@@ -158,47 +158,47 @@
         },
         "black": {
             "hashes": [
-                "sha256:01ede61aac8c154b55f35301fac3e730baf0c9cf8120f65a9cd61a81cfb4a0c3",
-                "sha256:022a582720b0d9480ed82576c920a8c1dde97cc38ff11d8d8859b3bd6ca9eedb",
-                "sha256:25cc308838fe71f7065df53aedd20327969d05671bac95b38fdf37ebe70ac087",
-                "sha256:27eb7a0c71604d5de083757fbdb245b1a4fae60e9596514c6ec497eb63f95320",
-                "sha256:327a8c2550ddc573b51e2c352adb88143464bb9d92c10416feb86b0f5aee5ff6",
-                "sha256:47e56d83aad53ca140da0af87678fb38e44fd6bc0af71eebab2d1f59b1acf1d3",
-                "sha256:501387a9edcb75d7ae8a4412bb8749900386eaef258f1aefab18adddea1936bc",
-                "sha256:552513d5cd5694590d7ef6f46e1767a4df9af168d449ff767b13b084c020e63f",
-                "sha256:5c4bc552ab52f6c1c506ccae05681fab58c3f72d59ae6e6639e8885e94fe2587",
-                "sha256:642496b675095d423f9b8448243336f8ec71c9d4d57ec17bf795b67f08132a91",
-                "sha256:6d1c6022b86f83b632d06f2b02774134def5d4d4f1dac8bef16d90cda18ba28a",
-                "sha256:7f3bf2dec7d541b4619b8ce526bda74a6b0bffc480a163fed32eb8b3c9aed8ad",
-                "sha256:831d8f54c3a8c8cf55f64d0422ee875eecac26f5f649fb6c1df65316b67c8926",
-                "sha256:8417dbd2f57b5701492cd46edcecc4f9208dc75529bcf76c514864e48da867d9",
-                "sha256:86cee259349b4448adb4ef9b204bb4467aae74a386bce85d56ba4f5dc0da27be",
-                "sha256:893695a76b140881531062d48476ebe4a48f5d1e9388177e175d76234ca247cd",
-                "sha256:9fd59d418c60c0348505f2ddf9609c1e1de8e7493eab96198fc89d9f865e7a96",
-                "sha256:ad0014efc7acf0bd745792bd0d8857413652979200ab924fbf239062adc12491",
-                "sha256:b5b0ee6d96b345a8b420100b7d71ebfdd19fab5e8301aff48ec270042cd40ac2",
-                "sha256:c333286dc3ddca6fdff74670b911cccedacb4ef0a60b34e491b8a67c833b343a",
-                "sha256:f9062af71c59c004cd519e2fb8f5d25d39e46d3af011b41ab43b9c74e27e236f",
-                "sha256:fb074d8b213749fa1d077d630db0d5f8cc3b2ae63587ad4116e8a436e9bbe995"
+                "sha256:031e8c69f3d3b09e1aa471a926a1eeb0b9071f80b17689a655f7885ac9325a6f",
+                "sha256:13a2e4a93bb8ca74a749b6974925c27219bb3df4d42fc45e948a5d9feb5122b7",
+                "sha256:13ef033794029b85dfea8032c9d3b92b42b526f1ff4bf13b2182ce4e917f5100",
+                "sha256:14f04c990259576acd093871e7e9b14918eb28f1866f91968ff5524293f9c573",
+                "sha256:24b6b3ff5c6d9ea08a8888f6977eae858e1f340d7260cf56d70a49823236b62d",
+                "sha256:403397c033adbc45c2bd41747da1f7fc7eaa44efbee256b53842470d4ac5a70f",
+                "sha256:50254ebfa56aa46a9fdd5d651f9637485068a1adf42270148cd101cdf56e0ad9",
+                "sha256:538efb451cd50f43aba394e9ec7ad55a37598faae3348d723b59ea8e91616300",
+                "sha256:638619a559280de0c2aa4d76f504891c9860bb8fa214267358f0a20f27c12948",
+                "sha256:6a3b50e4b93f43b34a9d3ef00d9b6728b4a722c997c99ab09102fd5efdb88325",
+                "sha256:6ccd59584cc834b6d127628713e4b6b968e5f79572da66284532525a042549f9",
+                "sha256:75a2dc41b183d4872d3a500d2b9c9016e67ed95738a3624f4751a0cb4818fe71",
+                "sha256:7d30ec46de88091e4316b17ae58bbbfc12b2de05e069030f6b747dfc649ad186",
+                "sha256:8431445bf62d2a914b541da7ab3e2b4f3bc052d2ccbf157ebad18ea126efb91f",
+                "sha256:8fc1ddcf83f996247505db6b715294eba56ea9372e107fd54963c7553f2b6dfe",
+                "sha256:a732b82747235e0542c03bf352c126052c0fbc458d8a239a94701175b17d4855",
+                "sha256:adc3e4442eef57f99b5590b245a328aad19c99552e0bdc7f0b04db6656debd80",
+                "sha256:c46767e8df1b7beefb0899c4a95fb43058fa8500b6db144f4ff3ca38eb2f6393",
+                "sha256:c619f063c2d68f19b2d7270f4cf3192cb81c9ec5bc5ba02df91471d0b88c4c5c",
+                "sha256:cf3a4d00e4cdb6734b64bf23cd4341421e8953615cba6b3670453737a72ec204",
+                "sha256:cf99f3de8b3273a8317681d8194ea222f10e0133a24a7548c73ce44ea1679377",
+                "sha256:d6bc09188020c9ac2555a498949401ab35bb6bf76d4e0f8ee251694664df6301"
             ],
             "index": "pypi",
-            "version": "==23.7.0"
+            "version": "==23.9.1"
         },
         "boto3": {
             "hashes": [
-                "sha256:734bf24b9240a366b4a0d7e37433ef01664a3568d8bb65be583cc2a4ed2947c5",
-                "sha256:9f36834a1a777002b4b4600415ced83bc62d42b9c36d8c75f5fc007a58d0ae17"
+                "sha256:8149f17587c68e556743018f213f00ece81a0f021adb9b9b697a2ee8802583d7",
+                "sha256:8860ab54a26d1d596d64fc9de7e40c4d7c53c100311208cbd90d9272c3385513"
             ],
             "index": "pypi",
-            "version": "==1.28.42"
+            "version": "==1.28.51"
         },
         "botocore": {
             "hashes": [
-                "sha256:a51607e9f367e53768d37eacde244bc31dbaff4e7dde453cc772a8f75648f04a",
-                "sha256:cedf7d5eb55f120faadd56d3bced2139523479adb4df62c0c5ee5d46b2ffa836"
+                "sha256:8e133add22f07b55d21e14176b97b82e993d5f9aca70f5b0cd0908cb105ba53a",
+                "sha256:91dfb38801d45214875a892bd1e908fc7a894c2ed170bacd67e6929af72f2bd2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.42"
+            "version": "==1.31.51"
         },
         "certifi": {
             "hashes": [
@@ -440,32 +440,32 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0d09fb5356f975974dbcb595ad2d178305e5050656affb7890a1583f5e02a306",
-                "sha256:23c2d778cf829f7d0ae180600b17e9fceea3c2ef8b31a99e3c694cbbf3a24b84",
-                "sha256:3fb248989b6363906827284cd20cca63bb1a757e0a2864d4c1682a985e3dca47",
-                "sha256:41d7aa7cdfded09b3d73a47f429c298e80796c8e825ddfadc84c8a7f12df212d",
-                "sha256:42cb413e01a5d36da9929baa9d70ca90d90b969269e5a12d39c1e0d475010116",
-                "sha256:4c2f0d35703d61002a2bbdcf15548ebb701cfdd83cdc12471d2bae80878a4207",
-                "sha256:4fd871184321100fb400d759ad0cddddf284c4b696568204d281c902fc7b0d81",
-                "sha256:5259cb659aa43005eb55a0e4ff2c825ca111a0da1814202c64d28a985d33b087",
-                "sha256:57a51b89f954f216a81c9d057bf1a24e2f36e764a1ca9a501a6964eb4a6800dd",
-                "sha256:652627a055cb52a84f8c448185922241dd5217443ca194d5739b44612c5e6507",
-                "sha256:67e120e9a577c64fe1f611e53b30b3e69744e5910ff3b6e97e935aeb96005858",
-                "sha256:6af1c6387c531cd364b72c28daa29232162010d952ceb7e5ca8e2827526aceae",
-                "sha256:6d192741113ef5e30d89dcb5b956ef4e1578f304708701b8b73d38e3e1461f34",
-                "sha256:7efe8041897fe7a50863e51b77789b657a133c75c3b094e51b5e4b5cec7bf906",
-                "sha256:84537453d57f55a50a5b6835622ee405816999a7113267739a1b4581f83535bd",
-                "sha256:8f09daa483aedea50d249ef98ed500569841d6498aa9c9f4b0531b9964658922",
-                "sha256:95dd7f261bb76948b52a5330ba5202b91a26fbac13ad0e9fc8a3ac04752058c7",
-                "sha256:a74fbcdb2a0d46fe00504f571a2a540532f4c188e6ccf26f1f178480117b33c4",
-                "sha256:a983e441a00a9d57a4d7c91b3116a37ae602907a7618b882c8013b5762e80574",
-                "sha256:ab8de0d091acbf778f74286f4989cf3d1528336af1b59f3e5d2ebca8b5fe49e1",
-                "sha256:aeb57c421b34af8f9fe830e1955bf493a86a7996cc1338fe41b30047d16e962c",
-                "sha256:ce785cf81a7bdade534297ef9e490ddff800d956625020ab2ec2780a556c313e",
-                "sha256:d0d651aa754ef58d75cec6edfbd21259d93810b73f6ec246436a21b7841908de"
+                "sha256:004b6ccc95943f6a9ad3142cfabcc769d7ee38a3f60fb0dddbfb431f818c3a67",
+                "sha256:047c4603aeb4bbd8db2756e38f5b8bd7e94318c047cfe4efeb5d715e08b49311",
+                "sha256:0d9409894f495d465fe6fda92cb70e8323e9648af912d5b9141d616df40a87b8",
+                "sha256:23a25c09dfd0d9f28da2352503b23e086f8e78096b9fd585d1d14eca01613e13",
+                "sha256:2ed09183922d66c4ec5fdaa59b4d14e105c084dd0febd27452de8f6f74704143",
+                "sha256:35c00f637cd0b9d5b6c6bd11b6c3359194a8eba9c46d4e875a3660e3b400005f",
+                "sha256:37480760ae08065437e6573d14be973112c9e6dcaf5f11d00147ee74f37a3829",
+                "sha256:3b224890962a2d7b57cf5eeb16ccaafba6083f7b811829f00476309bce2fe0fd",
+                "sha256:5a0f09cefded00e648a127048119f77bc2b2ec61e736660b5789e638f43cc397",
+                "sha256:5b72205a360f3b6176485a333256b9bcd48700fc755fef51c8e7e67c4b63e3ac",
+                "sha256:7e53db173370dea832190870e975a1e09c86a879b613948f09eb49324218c14d",
+                "sha256:7febc3094125fc126a7f6fb1f420d0da639f3f32cb15c8ff0dc3997c4549f51a",
+                "sha256:80907d3faa55dc5434a16579952ac6da800935cd98d14dbd62f6f042c7f5e839",
+                "sha256:86defa8d248c3fa029da68ce61fe735432b047e32179883bdb1e79ed9bb8195e",
+                "sha256:8ac4f9ead4bbd0bc8ab2d318f97d85147167a488be0e08814a37eb2f439d5cf6",
+                "sha256:93530900d14c37a46ce3d6c9e6fd35dbe5f5601bf6b3a5c325c7bffc030344d9",
+                "sha256:9eeb77214afae972a00dee47382d2591abe77bdae166bda672fb1e24702a3860",
+                "sha256:b5f4dfe950ff0479f1f00eda09c18798d4f49b98f4e2006d644b3301682ebdca",
+                "sha256:c3391bd8e6de35f6f1140e50aaeb3e2b3d6a9012536ca23ab0d9c35ec18c8a91",
+                "sha256:c880eba5175f4307129784eca96f4e70b88e57aa3f680aeba3bab0e980b0f37d",
+                "sha256:cecfefa17042941f94ab54f769c8ce0fe14beff2694e9ac684176a2535bf9714",
+                "sha256:e40211b4923ba5a6dc9769eab704bdb3fbb58d56c5b336d30996c24fcf12aadb",
+                "sha256:efc8ad4e6fc4f1752ebfb58aefece8b4e3c4cae940b0994d43649bdfce8d0d4f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==41.0.3"
+            "version": "==41.0.4"
         },
         "dill": {
             "hashes": [
@@ -506,11 +506,11 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:9cbefbd1789a5fe9bcf621bb34d3f441f3a90c8461d377f84eda73e721d9b06b",
-                "sha256:c19b4292d7a1d3c0f653858db273ff8a6614100d1eb1528b014ec97286193c09"
+                "sha256:4bb0c2a6995e85064140d31a33289aa5dce80133a23d36fcd372d716c54d3ebf",
+                "sha256:8d22b5cfefd17c79914226982bb7851d6ade47545b1735a9d010a2a4c26d8388"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.35"
+            "version": "==3.1.36"
         },
         "idna": {
             "hashes": [
@@ -615,8 +615,11 @@
                 "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
                 "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431",
                 "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686",
+                "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c",
                 "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559",
                 "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc",
+                "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb",
+                "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939",
                 "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c",
                 "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0",
                 "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4",
@@ -624,6 +627,7 @@
                 "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575",
                 "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
                 "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d",
+                "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd",
                 "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3",
                 "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00",
                 "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155",
@@ -632,6 +636,7 @@
                 "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f",
                 "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8",
                 "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+                "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007",
                 "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24",
                 "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea",
                 "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
@@ -639,9 +644,12 @@
                 "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee",
                 "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be",
                 "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2",
+                "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1",
                 "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707",
                 "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6",
+                "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c",
                 "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
+                "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823",
                 "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779",
                 "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
                 "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c",
@@ -660,7 +668,9 @@
                 "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9",
                 "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57",
                 "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc",
-                "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2"
+                "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc",
+                "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2",
+                "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.1.3"
@@ -686,11 +696,11 @@
                 "s3"
             ],
             "hashes": [
-                "sha256:2a9cbcd9da1a66b23f95d62ef91968284445233a606b4de949379395056276fb",
-                "sha256:ee34c4c3f53900d953180946920c9dba127a483e2ed40e6dbf93d4ae2e760e7c"
+                "sha256:2e934d834729b274382055e097b166127db829ab4fae00bb08c031c108391a2c",
+                "sha256:4caab0145d557d102fe79d0ce3b73d6bf1d916d29ad03c14da15f7da66429cdb"
             ],
             "index": "pypi",
-            "version": "==4.2.2"
+            "version": "==4.2.3"
         },
         "mypy": {
             "hashes": [
@@ -775,10 +785,10 @@
         },
         "py-partiql-parser": {
             "hashes": [
-                "sha256:c03568d15a5e04e802b43c6066a07a7409825d6b02da6c70f60e520ca32a4995",
-                "sha256:edc61645f99076eee660fe30f0bc67b04ce1e0e750d56af8932b229f012bb40d"
+                "sha256:5341f1adc3bdd5dbe7c980fc17b3a4a6353c9052e5b5dd70f6aff9306fb8cbb2",
+                "sha256:e18696b40b9733b1e4b312969f8210fcde24e0766e2a0da799e8f70a5594d6ab"
             ],
-            "version": "==0.3.6"
+            "version": "==0.3.7"
         },
         "pycodestyle": {
             "hashes": [
@@ -839,11 +849,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:2f2301e797521b23e4d2585a0a3d7b5e50fdddaaf7e7d6773ea26ddb17c213ab",
-                "sha256:460c9a59b14e27c602eb5ece2e47bec99dc5fc5f6513cf924a7d03a578991b1f"
+                "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002",
+                "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"
             ],
             "index": "pypi",
-            "version": "==7.4.1"
+            "version": "==7.4.2"
         },
         "python-dateutil": {
             "hashes": [
@@ -934,11 +944,11 @@
         },
         "rich": {
             "hashes": [
-                "sha256:146a90b3b6b47cac4a73c12866a499e9817426423f57c5a66949c086191a8808",
-                "sha256:fb9d6c0a0f643c99eed3875b5377a184132ba9be4d61516a55273d3554d75a39"
+                "sha256:87b43e0543149efa1253f485cd845bb7ee54df16c9617b8a893650ab84b4acb6",
+                "sha256:9257b468badc3d347e146a4faa268ff229039d4c2d176ab0cffb4c4fbc73d5d9"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==13.5.2"
+            "version": "==13.5.3"
         },
         "s3transfer": {
             "hashes": [
@@ -958,11 +968,11 @@
         },
         "smmap": {
             "hashes": [
-                "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94",
-                "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"
+                "sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62",
+                "sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==5.0.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==5.0.1"
         },
         "snowballstemmer": {
             "hashes": [
@@ -1012,11 +1022,11 @@
         },
         "types-requests": {
             "hashes": [
-                "sha256:56d181c85b5925cbc59f4489a57e72a8b2166f18273fd8ba7b6fe0c0b986f12a",
-                "sha256:6aa3f7faf0ea52d728bb18c0a0d1522d9bfd8c72d26ff6f61bfc3d06a411cf40"
+                "sha256:938f51653c757716aeca5d72c405c5e2befad8b0d330e3b385ce7f148e1b10dc",
+                "sha256:d5d7a08965fca12bedf716eaf5430c6e3d0da9f3164a1dba2a7f3885f9ebe3c0"
             ],
             "index": "pypi",
-            "version": "==2.31.0.2"
+            "version": "==2.31.0.3"
         },
         "types-urllib3": {
             "hashes": [
@@ -1028,11 +1038,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
-                "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
+                "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
+                "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
             ],
             "markers": "python_version < '3.12'",
-            "version": "==4.7.1"
+            "version": "==4.8.0"
         },
         "urllib3": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,38 +18,38 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:8149f17587c68e556743018f213f00ece81a0f021adb9b9b697a2ee8802583d7",
-                "sha256:8860ab54a26d1d596d64fc9de7e40c4d7c53c100311208cbd90d9272c3385513"
+                "sha256:1d36db102517d62c6968b3b0636303241f56859d12dd071def4882fc6e030b20",
+                "sha256:a34fc153cb2f6fb2f79a764286c967392e8aae9412381d943bddc576c4f7631a"
             ],
             "index": "pypi",
-            "version": "==1.28.51"
+            "version": "==1.28.52"
         },
         "boto3-stubs": {
             "extras": [
                 "s3"
             ],
             "hashes": [
-                "sha256:67608ad5ccd862494dc4aac8dc7596393f3d9cd2123a78bcd1f3ac46f3799cb3",
-                "sha256:6ebd53a356faaf576b3dd77c0923ab725b51da46d85adf6e2a89569b360490c0"
+                "sha256:12d7e5865aeec52e1f73b935b1c6a42e61325538fc2cb83a87a83e41e9485241",
+                "sha256:3ea81a225e062f3bcb205467891086ea031519697ad54622e61251b52609b8d6"
             ],
             "index": "pypi",
-            "version": "==1.28.51"
+            "version": "==1.28.52"
         },
         "botocore": {
             "hashes": [
-                "sha256:8e133add22f07b55d21e14176b97b82e993d5f9aca70f5b0cd0908cb105ba53a",
-                "sha256:91dfb38801d45214875a892bd1e908fc7a894c2ed170bacd67e6929af72f2bd2"
+                "sha256:46b0a75a38521aa6a75fddccb1542e002930e609d4e13516f40fef170d32e515",
+                "sha256:6d09881c5a8be34b497872ca3936f8757d886a6f42f2a8703411928189cfedc0"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.51"
+            "version": "==1.31.52"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:159a57ff41ed16940da6c3e0ee2f4d9571bc6d345a1f41b36a85a093dd15aeff",
-                "sha256:a31d93723fab3cd40cefb3c82ce7fe86bb901ee52cee20424e949118028afc26"
+                "sha256:11431ac0faa35cad6deed6e87002f312f8ea6358d8106a241b60bcead2f84279",
+                "sha256:2fa9b78c7a335a94d918079773dc3198786de741586187d847a8710b9c337009"
             ],
             "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==1.31.51"
+            "version": "==1.31.52"
         },
         "certifi": {
             "hashes": [
@@ -69,10 +69,10 @@
         },
         "mypy-boto3-s3": {
             "hashes": [
-                "sha256:44da375fd4d75b1c5ccc26dcd3be48294c7061445efd6d90ebfca43ffebbb3e4",
-                "sha256:d0e90074e4043edf420292397012e37309ff204442a0874d8c969f56546be665"
+                "sha256:179cb7542cc5ef656f1323ad51eb237afcba77d1e5ed07d21a013fe36effb8b2",
+                "sha256:a75cd5ff28f1cb5109dd50db94259436701208fa97c61b5a2cc0689e169b7cba"
             ],
-            "version": "==1.28.36"
+            "version": "==1.28.52"
         },
         "python-dateutil": {
             "hashes": [
@@ -186,19 +186,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:8149f17587c68e556743018f213f00ece81a0f021adb9b9b697a2ee8802583d7",
-                "sha256:8860ab54a26d1d596d64fc9de7e40c4d7c53c100311208cbd90d9272c3385513"
+                "sha256:1d36db102517d62c6968b3b0636303241f56859d12dd071def4882fc6e030b20",
+                "sha256:a34fc153cb2f6fb2f79a764286c967392e8aae9412381d943bddc576c4f7631a"
             ],
             "index": "pypi",
-            "version": "==1.28.51"
+            "version": "==1.28.52"
         },
         "botocore": {
             "hashes": [
-                "sha256:8e133add22f07b55d21e14176b97b82e993d5f9aca70f5b0cd0908cb105ba53a",
-                "sha256:91dfb38801d45214875a892bd1e908fc7a894c2ed170bacd67e6929af72f2bd2"
+                "sha256:46b0a75a38521aa6a75fddccb1542e002930e609d4e13516f40fef170d32e515",
+                "sha256:6d09881c5a8be34b497872ca3936f8757d886a6f42f2a8703411928189cfedc0"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.51"
+            "version": "==1.31.52"
         },
         "certifi": {
             "hashes": [
@@ -506,11 +506,11 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:4bb0c2a6995e85064140d31a33289aa5dce80133a23d36fcd372d716c54d3ebf",
-                "sha256:8d22b5cfefd17c79914226982bb7851d6ade47545b1735a9d010a2a4c26d8388"
+                "sha256:5f4c4187de49616d710a77e98ddf17b4782060a1788df441846bddefbb89ab33",
+                "sha256:f9b9ddc0761c125d5780eab2d64be4873fc6817c2899cbcb34b02344bdc7bc54"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.36"
+            "version": "==3.1.37"
         },
         "idna": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ bursar's system.
   docker run --env-file .env -p 9000:8080 bursar_transfer:latest
   ```
 
-- Upload a sample bursar export .xml file to the `SOURCE_BUCKET` specified in your `.env`. rename the file and move to a different subfolder if necessary so that the object key looks like `[SOURCE_PREFIX]-[job_id]-[timestamp].xml`
+- Upload a sample bursar export .xml file to the `SOURCE_BUCKET` specified in your `.env`. Rename the file and move to a different subfolder if necessary so that the object key looks like `[SOURCE_PREFIX]-[job_id]-[timestamp].xml`
   - For example the object key could be `test/bursar/export-1234-5678.xml`
   - Note that the timestamp can be any string, it doesn't have to be a 'real' timestamp
   - You can use the fixture file in this repo `tests/fixtures/test.xml` as your sample file.

--- a/README.md
+++ b/README.md
@@ -78,5 +78,8 @@ bursar's system.
 - Observe output:
 
   ```
-  {"target_file": "[TARGET_BUCKET]/[TARGET_PREFIX]-1234-5678.csv"}
+  {"target_file": "[TARGET_BUCKET]/[TARGET_PREFIX]-1234-5678.csv",
+  "records": [count of records in the file],
+  "total_charges: [sum of charges in the file]
+  }
   ```

--- a/lambdas/bursar_transfer.py
+++ b/lambdas/bursar_transfer.py
@@ -176,7 +176,7 @@ def get_records_and_total_charges(bursar_csv: StringIO) -> tuple[int, float]:
 
 
 def lambda_handler(event: dict, context: object) -> dict:  # noqa
-    logger.debug("lambda handler starting with event: %s", json.dumps(event))
+    logger.debug("Lambda handler starting with event: %s", json.dumps(event))
     if not os.getenv("WORKSPACE"):
         raise RuntimeError("Required env variable WORKSPACE is not set")
 

--- a/tests/fixtures/test.csv
+++ b/tests/fixtures/test.csv
@@ -1,2 +1,7 @@
 "MITID","STUDENTNAME","DETAILCODE","DESCRIPTION","AMOUNT","EFFECTIVEDATE","BILLINGTERM"
-"12345678","Transfer, Bursar","ROLH","LOSTITEMREPLACEMENTFEE","123.45","effective_date","2023SP"
+"12345678","Transfer, Bursar","ROLH","OVERDUEFINE","123.45","effective_date","2023SP"
+"12345678","Transfer, Bursar","ROLH","OVERDUEFINE","0.82","effective_date","2023SP"
+"12345678","Transfer, Bursar","ROLH","LOSTITEMREPLACEMENTFEE","300","effective_date","2023SP"
+"12345678","Transfer, Bursar","ROLH","OVERDUEFINE","1.45","effective_date","2023SP"
+"09876","The Beaver, Tim","ROLH","LOSTITEMREPLACEMENTFEE","100","effective_date","2023SP"
+"09876","The Beaver, Tim","ROLH","OVERDUEFINE","14","effective_date","2023SP"

--- a/tests/fixtures/test.xml
+++ b/tests/fixtures/test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xb:xml-fragment xmlns:xb="http://com/exlibris/urm/rep/externalsysfinesfees/xmlbeans">
 	<xb:userExportedFineFees>
-		<xb:exportNumber>13592334070006761</xb:exportNumber>
+		<xb:exportNumber>15216075870006761</xb:exportNumber>
 	</xb:userExportedFineFees>
 	<xb:userExportedFineFees>
 		<xb:userExportedList>
@@ -18,13 +18,13 @@
 					<xb:userFineFee>
 						<xb:fineFeeComment xsi:nil="true"
 							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
-						<xb:fineFeeType>LOSTITEMREPLACEMENTFEE</xb:fineFeeType>
+						<xb:fineFeeType>OVERDUEFINE</xb:fineFeeType>
 						<xb:owneredEntity>
 							<xb:InstitutionId>6761</xb:InstitutionId>
 							<xb:libraryId>161686070006761</xb:libraryId>
 							<xb:libraryCode>RTC</xb:libraryCode>
 						</xb:owneredEntity>
-						<xb:lastTransactionDate>05/12/2023 00:08:34</xb:lastTransactionDate>
+						<xb:lastTransactionDate>09/12/2023 15:22:06</xb:lastTransactionDate>
 						<xb:itemTitle>Ecology of the saguaro /</xb:itemTitle>
 						<xb:itemCallNumebr>QK495.C11 S64 1977</xb:itemCallNumebr>
 						<xb:itemLibrary>Hayden Library.</xb:itemLibrary>
@@ -39,7 +39,151 @@
 							<xb:vat xsi:nil="true"
 								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
 						</xb:compositeSum>
-						<xb:bursarTransactionId>13592333900006761</xb:bursarTransactionId>
+						<xb:bursarTransactionId>15216075630006761</xb:bursarTransactionId>
+					</xb:userFineFee>
+					<xb:userFineFee>
+						<xb:fineFeeComment xsi:nil="true"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						<xb:fineFeeType>OVERDUEFINE</xb:fineFeeType>
+						<xb:owneredEntity>
+							<xb:InstitutionId>6761</xb:InstitutionId>
+							<xb:libraryId>161686070006761</xb:libraryId>
+							<xb:libraryCode>RTC</xb:libraryCode>
+						</xb:owneredEntity>
+						<xb:lastTransactionDate>09/12/2023 15:22:26</xb:lastTransactionDate>
+						<xb:itemTitle>Ecology of the saguaro /</xb:itemTitle>
+						<xb:itemCallNumebr>QK495.C11 S64 1977</xb:itemCallNumebr>
+						<xb:itemLibrary>Hayden Library.</xb:itemLibrary>
+						<xb:itemLocation>Stacks</xb:itemLocation>
+						<xb:itemInternalLocation>Stacks</xb:itemInternalLocation>
+						<xb:itemDueDate xsi:nil="true"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						<xb:itemBarcode>39080036507785</xb:itemBarcode>
+						<xb:compositeSum>
+							<xb:currency>USD</xb:currency>
+							<xb:sum>0.82</xb:sum>
+							<xb:vat xsi:nil="true"
+								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						</xb:compositeSum>
+						<xb:bursarTransactionId>15216075640006761</xb:bursarTransactionId>
+					</xb:userFineFee>
+					<xb:userFineFee>
+						<xb:fineFeeComment xsi:nil="true"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						<xb:fineFeeType>LOSTITEMREPLACEMENTFEE</xb:fineFeeType>
+						<xb:owneredEntity>
+							<xb:InstitutionId>6761</xb:InstitutionId>
+							<xb:libraryId>161686070006761</xb:libraryId>
+							<xb:libraryCode>RTC</xb:libraryCode>
+						</xb:owneredEntity>
+						<xb:lastTransactionDate>09/12/2023 15:15:23</xb:lastTransactionDate>
+						<xb:itemTitle>The Rough-Stuff Fellowship archive /</xb:itemTitle>
+						<xb:itemCallNumebr>GV1056.R68 2019</xb:itemCallNumebr>
+						<xb:itemLibrary>Hayden Library</xb:itemLibrary>
+						<xb:itemLocation>Stacks</xb:itemLocation>
+						<xb:itemInternalLocation>Stacks</xb:itemInternalLocation>
+						<xb:itemDueDate xsi:nil="true"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						<xb:itemBarcode>39080037379556</xb:itemBarcode>
+						<xb:compositeSum>
+							<xb:currency>USD</xb:currency>
+							<xb:sum>300</xb:sum>
+							<xb:vat xsi:nil="true"
+								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						</xb:compositeSum>
+						<xb:bursarTransactionId>15216075490006761</xb:bursarTransactionId>
+					</xb:userFineFee>
+					<xb:userFineFee>
+						<xb:fineFeeComment xsi:nil="true"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						<xb:fineFeeType>OVERDUEFINE</xb:fineFeeType>
+						<xb:owneredEntity>
+							<xb:InstitutionId>6761</xb:InstitutionId>
+							<xb:libraryId>161686070006761</xb:libraryId>
+							<xb:libraryCode>RTC</xb:libraryCode>
+						</xb:owneredEntity>
+						<xb:lastTransactionDate>09/12/2023 15:22:53</xb:lastTransactionDate>
+						<xb:itemTitle>The Rough-Stuff Fellowship archive /</xb:itemTitle>
+						<xb:itemCallNumebr>GV1056.R68 2019</xb:itemCallNumebr>
+						<xb:itemLibrary>Hayden Library</xb:itemLibrary>
+						<xb:itemLocation>Stacks</xb:itemLocation>
+						<xb:itemInternalLocation>Stacks</xb:itemInternalLocation>
+						<xb:itemDueDate xsi:nil="true"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						<xb:itemBarcode>39080037379556</xb:itemBarcode>
+						<xb:compositeSum>
+							<xb:currency>USD</xb:currency>
+							<xb:sum>1.45</xb:sum>
+							<xb:vat xsi:nil="true"
+								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						</xb:compositeSum>
+						<xb:bursarTransactionId>15216075650006761</xb:bursarTransactionId>
+					</xb:userFineFee>
+				</xb:finefeeList>
+			</xb:userExportedFineFeesList>
+			<xb:userExportedFineFeesList>
+				<xb:user>
+					<xb:type>02</xb:type>
+					<xb:value>09876</xb:value>
+					<xb:owneredEntity>
+						<xb:InstitutionId>6761</xb:InstitutionId>
+					</xb:owneredEntity>
+				</xb:user>
+				<xb:patronName>The Beaver, Tim</xb:patronName>
+				<xb:finefeeList>
+					<xb:userFineFee>
+						<xb:fineFeeComment xsi:nil="true"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						<xb:fineFeeType>LOSTITEMREPLACEMENTFEE</xb:fineFeeType>
+						<xb:owneredEntity>
+							<xb:InstitutionId>6761</xb:InstitutionId>
+							<xb:libraryId>161686070006761</xb:libraryId>
+							<xb:libraryCode>RTC</xb:libraryCode>
+						</xb:owneredEntity>
+						<xb:lastTransactionDate>09/12/2023 15:24:14</xb:lastTransactionDate>
+						<xb:itemTitle>Case studies of child play areas and child support facilities
+							: travel and field research report /</xb:itemTitle>
+						<xb:itemCallNumebr>HV854.C56</xb:itemCallNumebr>
+						<xb:itemLibrary>Rotch Library</xb:itemLibrary>
+						<xb:itemLocation>Stacks</xb:itemLocation>
+						<xb:itemInternalLocation>Stacks</xb:itemInternalLocation>
+						<xb:itemDueDate xsi:nil="true"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						<xb:itemBarcode>39080002699707</xb:itemBarcode>
+						<xb:compositeSum>
+							<xb:currency>USD</xb:currency>
+							<xb:sum>100</xb:sum>
+							<xb:vat xsi:nil="true"
+								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						</xb:compositeSum>
+						<xb:bursarTransactionId>15216075700006761</xb:bursarTransactionId>
+					</xb:userFineFee>
+					<xb:userFineFee>
+						<xb:fineFeeComment xsi:nil="true"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						<xb:fineFeeType>OVERDUEFINE</xb:fineFeeType>
+						<xb:owneredEntity>
+							<xb:InstitutionId>6761</xb:InstitutionId>
+							<xb:libraryId>161686070006761</xb:libraryId>
+							<xb:libraryCode>RTC</xb:libraryCode>
+						</xb:owneredEntity>
+						<xb:lastTransactionDate>09/12/2023 15:23:25</xb:lastTransactionDate>
+						<xb:itemTitle>Case studies of child play areas and child support facilities
+							: travel and field research report /</xb:itemTitle>
+						<xb:itemCallNumebr>HV854.C56</xb:itemCallNumebr>
+						<xb:itemLibrary>Rotch Library</xb:itemLibrary>
+						<xb:itemLocation>Stacks</xb:itemLocation>
+						<xb:itemInternalLocation>Stacks</xb:itemInternalLocation>
+						<xb:itemDueDate xsi:nil="true"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						<xb:itemBarcode>39080002699707</xb:itemBarcode>
+						<xb:compositeSum>
+							<xb:currency>USD</xb:currency>
+							<xb:sum>14</xb:sum>
+							<xb:vat xsi:nil="true"
+								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+						</xb:compositeSum>
+						<xb:bursarTransactionId>15216075690006761</xb:bursarTransactionId>
 					</xb:userFineFee>
 				</xb:finefeeList>
 			</xb:userExportedFineFeesList>

--- a/tests/test_bursar_transfer.py
+++ b/tests/test_bursar_transfer.py
@@ -156,6 +156,6 @@ def test_lambda_handler_success(event_data, caplog) -> None:
     assert f"Bursar csv available for download at {csv_location}" in caplog.text
     assert response == {
         "target_file": csv_location,
-        "records": records,
+        "record_count": records,
         "total_charges": total_charges,
     }

--- a/tests/test_bursar_transfer.py
+++ b/tests/test_bursar_transfer.py
@@ -147,7 +147,7 @@ def test_lambda_handler_success(event_data, caplog) -> None:
     with caplog.at_level(logging.DEBUG, logger="lambdas.bursar_transfer"):
         response = bursar_transfer.lambda_handler(event_data, {})
     assert (
-        f"lambda handler starting with event: {json.dumps(event_data)}" in caplog.text
+        f"Lambda handler starting with event: {json.dumps(event_data)}" in caplog.text
     )
 
     records = 6

--- a/tests/test_bursar_transfer.py
+++ b/tests/test_bursar_transfer.py
@@ -105,10 +105,12 @@ def test_xml_to_csv_error_if_missing_field(test_xml: str) -> None:
 
 
 def test_xml_to_csv(test_xml: str) -> None:
-    with open("tests/fixtures/test.csv", encoding="utf-8") as file:
-        expected_file = file.read()
+    with open("tests/fixtures/test.csv", encoding="utf-8") as expected_file:
         today = date(2023, 3, 1)
-        assert bursar_transfer.xml_to_csv(test_xml, today) == expected_file
+        assert (
+            bursar_transfer.xml_to_csv(test_xml, today).getvalue()
+            == expected_file.read()
+        )
 
 
 def test_put_csv(mocked_s3) -> None:
@@ -148,5 +150,12 @@ def test_lambda_handler_success(event_data, caplog) -> None:
         f"lambda handler starting with event: {json.dumps(event_data)}" in caplog.text
     )
 
+    records = 6
+    total_charges = 539.72
+    response = bursar_transfer.lambda_handler(event_data, {})
     assert f"Bursar csv available for download at {csv_location}" in caplog.text
-    assert response == {"target_file": csv_location}
+    assert response == {
+        "target_file": csv_location,
+        "records": records,
+        "total_charges": total_charges,
+    }


### PR DESCRIPTION
### What does this PR do?
Adds record count and total amount of charges to the values returned by the lambda 
so that these value can be included in the success email triggered by the step function

### Helpful background context
The CHASS webform has required fields for total records and total charges when submitting
a file. We should send these value in the success email so that staff don't have to open the
datafile and calculate them. 

### How can a reviewer manually see the effects of these changes?

follow the local testing instruction in the readme. observe new return values.

### Includes new or updated dependencies?

YES

### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/ENSY-187

### Developer

- [ ] All new ENV is documented in README (or there is none)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
