### PR TITLE
Create Stage and Prod Automation Workflows

### DIFF
--- a/.github/workflows/prod_promote.yml
+++ b/.github/workflows/prod_promote.yml
@@ -1,0 +1,20 @@
+### This is the Terraform-generated prod-promote.yml workflow for the alma-bursartransfer-prod repository. ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document.                      ###
+name: Prod Container Promote
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Prod Container Promote
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-promote-prod.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE_STAGE: alma-bursartransfer-gha-stage
+      GHA_ROLE_PROD: alma-bursartransfer-gha-prod
+      ECR_STAGE: "alma-bursartransfer-stage"
+      ECR_PROD: "alma-bursartransfer-prod"
+      FUNCTION: "alma-bursartransfer-prod"

--- a/.github/workflows/stage_build.yml
+++ b/.github/workflows/stage_build.yml
@@ -1,0 +1,24 @@
+### This is the Terraform-generated dev-build.yml workflow for the alma-bursartransfer-stage app repository ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document                        ###
+### If the container requires any additional pre-build commands, uncomment and edit                         ###
+### the PREBUILD line at the end of the document.                                                           ###
+name: Stage Container Build and Deploy
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  deploy:
+    name: Stage Container Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-stage.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE: "alma-bursartransfer-gha-stage"
+      ECR: "alma-bursartransfer-stage"
+      FUNCTION: "alma-bursartransfer-stage"
+      # PREBUILD: 


### PR DESCRIPTION
### What does this PR do?

* Create the stage_build workflow for automated build/push of the container to ECR (triggered by commits to the `main` branch)
* Create the prod_promote workflow for automated download from stage and upload to prod ECR (triggered by tagged release on the `main` branch)

### Helpful background context

With the changes from mitlib-tf-workloads-ecr pushed to Dev1, Stage-Workloads, and Prod-Workloads, we can finish the GitHub Actions workflows for this repository.

Side effects of this change:
None. Other than the fact that every commit to the `main` branch will now automatically update the container image in the Stage-Workloads ECR repository

### How can a reviewer manually see the effects of these changes?

These are GitHub Actions for automation, so no easy way for a reviewer to test these. The code is automatically generated by the Terraform repo that builds the infrastructure.

### Includes new or updated dependencies?

NO

### What are the relevant tickets?

* [ENSY-177](https://mitlibraries.atlassian.net/browse/ENSY-177)

### Developer

- [N/A] All new ENV is documented in README (or there is none)
- [N/A] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes


[ENSY-177]: https://mitlibraries.atlassian.net/browse/ENSY-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ